### PR TITLE
Add simple position prediction, increase particle radius.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -12,6 +12,8 @@ local RAINGAIN = 0.2 -- Rain sound volume
 local COLLIDE = false -- Whether particles collide with nodes
 local NISVAL = 39 -- Clouds RGB value at night
 local DASVAL = 175 -- Clouds RGB value in daytime
+local FRADIUS = 48 -- Radius in which flakes are created
+local DRADIUS = 24 -- Radius in which drops are created
 
 local np_prec = {
 	offset = 0,
@@ -78,7 +80,10 @@ minetest.register_globalstep(function(dtime)
 
 	for _, player in ipairs(minetest.get_connected_players()) do
 		local player_name = player:get_player_name()
-		local ppos = player:getpos()
+		-- Predict player position as slightly behind the CYCLE interval.
+		-- Assume scheduling gets behind slighly (the 1.5), this also tested well.
+		local ppos = vector.add(player:getpos(),
+			vector.multiply(player:get_player_velocity(), GSCYCLE * 1.5))
 		local pposy = math.floor(ppos.y) + 2 -- Precipitation when swimming
 		if pposy >= YLIMIT - 2 then
 			local pposx = math.floor(ppos.x)
@@ -156,9 +161,9 @@ minetest.register_globalstep(function(dtime)
 					for flake = 1, FLAKES do
 						minetest.add_particle({
 							pos = {
-								x = pposx - 24 + math.random(0, 48),
+								x = pposx - FRADIUS + math.random(0, FRADIUS * 2),
 								y = pposy + 12,
-								z = pposz - 24 + math.random(0, 48)
+								z = pposz - FRADIUS + math.random(0, FRADIUS * 2)
 							},
 							velocity = {
 								x = (-20 + math.random(0, 40)) / 100,
@@ -183,9 +188,9 @@ minetest.register_globalstep(function(dtime)
 						local extime = math.min((spawny - YLIMIT) / 10, 1.8)
 						minetest.add_particle({
 							pos = {
-								x = pposx - 12 + math.random(0, 24),
+								x = pposx - DRADIUS + math.random(0, DRADIUS * 2),
 								y = spawny,
-								z = pposz - 12 + math.random(0, 24)
+								z = pposz - DRADIUS + math.random(0, DRADIUS * 2)
 							},
 							velocity = {
 								x = 0.0,


### PR DESCRIPTION
Fixes #4 

Simply predicts where the player will be the next time we are adding particles. Similar to what I added [added](https://github.com/minetest-mods/wielded_light/pull/3) to wielded_light.

Also doubles the radius. Together this makes for a much better experience when moving/flying around.
Could do the doubling of the radius separately, but without it even with prediction the effect is not nice, one can see the new particles popping into existence.
